### PR TITLE
Add progress bar and privacy hint to form generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 Webseite zur Generierung von Fallkonzepten.
 
 Das Dokument [KONZEPT.md](KONZEPT.md) beschreibt ein vereinfachtes Eingabekonzept mit überwiegend Auswahlfeldern und wenigen Freitextfeldern.
+
+## Hinweise
+
+- Ein Fortschrittsbalken und eine fixierte Navigation erleichtern die Orientierung in langen Formularen.
+- Pflichtfelder sind mit einem * markiert.
+- Alle eingegebenen Daten verbleiben lokal im Browser und werden nicht an einen Server übertragen.

--- a/index.html
+++ b/index.html
@@ -41,14 +41,15 @@
       <li data-step="8">Zusatz</li>
       <li data-step="9">Zusammenfassung</li>
     </ul>
+    <div id="progressBar"><div id="progress"></div></div>
     <form id="reportForm">
       <!-- Step 0: Auswahl des Antragstyps -->
       <div class="form-step" data-step="0">
         <h2>Antragstyp wählen</h2>
         <p>Bitte wählen Sie aus, welchen Antrag Sie stellen möchten.</p>
         <div class="input-group">
-          <label for="applicationType">Antragstyp</label>
-          <select id="applicationType" name="applicationType">
+          <label for="applicationType" class="required">Antragstyp</label>
+          <select id="applicationType" name="applicationType" required>
             <option value="erst">Erstantrag</option>
             <option value="umwandlung">Umwandlungsantrag (KZT → LZT)</option>
             <option value="fortfuehrung">Fortführungsantrag</option>
@@ -61,12 +62,12 @@
       <div class="form-step" data-step="1">
         <h2>1. Soziodemographische Daten</h2>
         <div class="input-group">
-          <label for="patientInitials">Patient:innen‑Chiffre / Initialen</label>
-          <input type="text" id="patientInitials" name="patientInitials" />
+          <label for="patientInitials" class="required">Patient:innen‑Chiffre / Initialen <span class="info-icon" title="Bitte anonymisierte Initialen oder eine Chiffre eintragen">i</span></label>
+          <input type="text" id="patientInitials" name="patientInitials" required />
         </div>
         <div class="input-group">
-          <label for="patientAge">Alter</label>
-          <input type="number" id="patientAge" name="patientAge" min="0" />
+          <label for="patientAge" class="required">Alter</label>
+          <input type="number" id="patientAge" name="patientAge" min="0" required />
         </div>
         <div class="input-group">
           <label for="patientGender">Geschlecht</label>
@@ -1271,7 +1272,13 @@
       </div>
     </form>
   </section>
-
+  <footer class="site-footer">
+    <p class="privacy-note">
+      Hinweis: Die eingegebenen Daten werden ausschließlich lokal im Browser verarbeitet
+      und nicht an einen Server gesendet. Bitte speichern Sie den Bericht nur auf
+      gesicherten Geräten und beachten Sie die geltenden Datenschutzrichtlinien (DSGVO).
+    </p>
+  </footer>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const steps = document.querySelectorAll(".form-step");
   const navItems = document.querySelectorAll("#stepNav li");
   let currentStep = 0;
+  const progressEl = document.getElementById("progress");
+  const totalSteps = steps.length - 1;
 
   // Geschlechtsauswahl: zeigt optionales Textfeld bei Auswahl "selbst angegeben"
   const genderSelect = document.getElementById("patientGender");
@@ -61,6 +63,10 @@ document.addEventListener("DOMContentLoaded", () => {
       navItems.forEach((nav) => {
         nav.classList.toggle("active", parseInt(nav.dataset.step, 10) === stepIndex);
       });
+      if (progressEl) {
+        const percent = (stepIndex / totalSteps) * 100;
+        progressEl.style.width = `${percent}%`;
+      }
       if (stepIndex === 9) {
         compileReport();
       }

--- a/style.css
+++ b/style.css
@@ -462,20 +462,21 @@ body.dark-mode .menu-toggle:hover {
   cursor: pointer;
   list-style: none;
   position: relative;
-  padding-left: 1.3rem;
+  padding: 0.4rem 0.8rem 0.4rem 1.6rem;
   margin-bottom: 0.5rem;
 }
 .details-group summary::before {
-  content: "▸";
+  content: "+";
   position: absolute;
   left: 0;
-  top: 2px;
-  font-size: 0.9rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1.1rem;
   line-height: 1;
-  transition: transform 0.2s ease;
+  transition: color 0.2s ease;
 }
 .details-group[open] summary::before {
-  transform: rotate(90deg);
+  content: "−";
 }
 
 /* Conditional note styling */
@@ -515,8 +516,12 @@ body.dark-mode .menu-toggle:hover {
   flex-wrap: wrap;
   list-style: none;
   gap: 0.5rem;
-  margin-bottom: 1rem;
-  padding: 0;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem 0;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: var(--surface-color);
 }
 .step-nav li {
   padding: 0.35rem 0.8rem;
@@ -531,10 +536,54 @@ body.dark-mode .menu-toggle:hover {
   background-color: var(--accent-color);
   color: var(--on-accent-color);
 }
+#progressBar {
+  height: 4px;
+  width: 100%;
+  background-color: var(--secondary-color);
+  margin-bottom: 1rem;
+}
+#progress {
+  height: 100%;
+  width: 0%;
+  background-color: var(--accent-color);
+  transition: width 0.3s ease;
+}
 .diagnosis-item {
   display: flex;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
+}
+
+label.required::after {
+  content: " *";
+  color: #d00;
+}
+
+.info-icon {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  margin-left: 0.25rem;
+  border-radius: 50%;
+  background-color: var(--accent-color);
+  color: var(--on-accent-color);
+  text-align: center;
+  font-size: 0.7rem;
+  line-height: 1rem;
+  cursor: help;
+}
+
+.site-footer {
+  margin-top: 2rem;
+  padding: 1rem;
+  font-size: 0.85rem;
+  text-align: center;
+  color: var(--subtext-color);
+}
+.privacy-note {
+  max-width: 800px;
+  margin: 0 auto;
+  line-height: 1.4;
 }
 .diagnosis-item .remove-diagnosis {
   background-color: var(--accent-color);


### PR DESCRIPTION
## Summary
- fix usability with sticky step navigation and visual progress bar
- mark required fields with asterisk and add helpful info icon
- show local data privacy note in footer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5c7983ea083299bb14b1024ce3bb7