### PR TITLE
Add sliding navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <button id="themeToggle" class="theme-toggle" title="Dark/Light Mode wechseln">🌙</button>
     </div>
   </header>
-  <nav id="headerMenu" class="header-menu hidden">
+  <nav id="headerMenu" class="header-menu">
     <ul>
       <li data-step="0">Antrag</li>
       <li data-step="1">Soziodemographie</li>

--- a/script.js
+++ b/script.js
@@ -73,6 +73,12 @@ document.addEventListener("DOMContentLoaded", () => {
       if (stepIndex === 9) {
         compileReport();
       }
+      // Aktives Element in der Navigationsleiste markieren
+      menuItems.forEach((item) => item.classList.remove("active"));
+      const activeItem = Array.from(menuItems).find(
+        (item) => parseInt(item.dataset.step, 10) === stepIndex
+      );
+      if (activeItem) activeItem.classList.add("active");
     }
   }
 
@@ -80,13 +86,13 @@ document.addEventListener("DOMContentLoaded", () => {
     item.addEventListener("click", () => {
       const step = parseInt(item.dataset.step, 10);
       showStep(step);
-      if (headerMenu) headerMenu.classList.add("hidden");
+      if (headerMenu) headerMenu.classList.remove("open");
     });
   });
 
   if (menuToggle && headerMenu) {
     menuToggle.addEventListener("click", () => {
-      headerMenu.classList.toggle("hidden");
+      headerMenu.classList.toggle("open");
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -72,6 +72,7 @@ body {
   color: var(--on-primary-color);
   box-shadow: 0 2px 6px var(--shadow-color);
   position: relative;
+  z-index: 100;
 }
 .nav-left {
   display: flex;
@@ -96,25 +97,38 @@ body.dark-mode .navbar-title {
 }
 
 .header-menu {
-  position: absolute;
-  top: 100%;
+  position: fixed;
+  top: 0;
   left: 0;
-  width: 100%;
-  background-color: rgba(0, 0, 0, 0.7);
-  padding: 0.5rem 1rem;
+  height: 100%;
+  width: 260px;
+  background-color: var(--primary-color);
+  box-shadow: 2px 0 8px var(--shadow-color);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  padding-top: 4rem;
   z-index: 90;
+}
+.header-menu.open {
+  transform: translateX(0);
 }
 .header-menu ul {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  justify-content: center;
-  gap: 1rem;
 }
 .header-menu li {
   cursor: pointer;
+  padding: 0.75rem 1rem;
   color: var(--on-primary-color);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+.header-menu li:hover {
+  background-color: var(--accent-hover-color);
+}
+.header-menu li.active {
+  background-color: var(--accent-color);
+  color: var(--on-accent-color);
 }
 .theme-toggle {
   padding: 0.35rem 0.8rem;


### PR DESCRIPTION
## Summary
- Implement slide-out sidebar toggled by hamburger menu
- Highlight active form step and close menu on selection
- Style new navigation for both light and dark modes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5e063e22083298db689b82893d9a6