### PR TITLE
Allow report export as PDF or Word

### DIFF
--- a/index.html
+++ b/index.html
@@ -1264,11 +1264,18 @@
       <!-- Step 9: Zusammenfassung & Report -->
       <div class="form-step" data-step="9">
         <h2>9. Zusammenfassung</h2>
-        <p>Im folgenden Feld sehen Sie Ihren generierten Bericht. Sie können diesen kopieren oder als Textdatei herunterladen.</p>
+        <p>Im folgenden Feld sehen Sie Ihren generierten Bericht. Sie können ihn als PDF‑ oder Word‑Datei herunterladen.</p>
         <textarea id="reportOutput" readonly rows="20"></textarea>
+        <div class="download-controls">
+          <label for="exportFormat">Exportformat:</label>
+          <select id="exportFormat">
+            <option value="pdf">PDF</option>
+            <option value="word">Word</option>
+          </select>
+          <button type="button" class="primary-btn" id="downloadReport">Herunterladen</button>
+        </div>
         <div class="navigation-buttons">
           <button type="button" class="secondary-btn" id="prev9">Zurück</button>
-          <button type="button" class="primary-btn" id="downloadReport">Herunterladen</button>
         </div>
       </div>
     </form>
@@ -1280,6 +1287,7 @@
       gesicherten Geräten und beachten Sie die geltenden Datenschutzrichtlinien (DSGVO).
     </p>
   </footer>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -624,15 +624,26 @@ document.addEventListener("DOMContentLoaded", () => {
   // Bericht herunterladen
   function downloadReport() {
     const text = document.getElementById("reportOutput").value;
-    const blob = new Blob([text], { type: "text/plain" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "bericht.txt";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+    const formatEl = document.getElementById("exportFormat");
+    const format = formatEl ? formatEl.value : "pdf";
+    if (format === "pdf") {
+      const { jsPDF } = window.jspdf;
+      const doc = new jsPDF();
+      const lines = doc.splitTextToSize(text, 180);
+      doc.text(lines, 10, 10);
+      doc.save("bericht.pdf");
+    } else if (format === "word") {
+      const content = `<html><head><meta charset="utf-8"></head><body><pre>${text}</pre></body></html>`;
+      const blob = new Blob(["\ufeff", content], { type: "application/msword" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "bericht.doc";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    }
   }
 
   addNavHandlers();

--- a/style.css
+++ b/style.css
@@ -379,6 +379,13 @@ body.dark-mode .menu-toggle:hover {
   margin-top: 2rem;
 }
 
+.download-controls {
+  margin-top: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 /*
   Gruppe von Checkboxen für übersichtliche Mehrfachauswahl.
   Die Checkboxen werden als pill‑förmige Schaltflächen dargestellt, um die Auswahl


### PR DESCRIPTION
## Summary
- Add format dropdown in summary step to select PDF or Word and include jsPDF
- Implement PDF and Word file generation for downloaded report
- Style new export controls

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5e4b2099483298fc4e38d132378d2